### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/authoring.rst
+++ b/docs/authoring.rst
@@ -265,7 +265,7 @@ browser tab with the rendered documentation.
 Try to ``touch docs/index.rst`` and watch the activity indicator in your
 browser – or take a look into the ``docs/watchdog.log`` file.
 
-.. _`rituals`: https://rituals.readthedocs.org/
+.. _`rituals`: https://rituals.readthedocs.io/
 
 
 Converting from Markdown to reST

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,10 +98,10 @@ References
 Tools
 ^^^^^
 
--  `Cookiecutter <http://cookiecutter.readthedocs.org/en/latest/>`_
+-  `Cookiecutter <https://cookiecutter.readthedocs.io/en/latest/>`_
 -  `PyInvoke <http://www.pyinvoke.org/>`_
 -  `pytest <http://pytest.org/latest/contents.html>`_
--  `tox <https://tox.readthedocs.org/en/latest/>`_
+-  `tox <https://tox.readthedocs.io/en/latest/>`_
 -  `Pylint <http://docs.pylint.org/>`_
 -  `pypa/setuptools <https://bitbucket.org/pypa/setuptools>`_
 -  `pypa/sampleproject <https://github.com/pypa/sampleproject>`_

--- a/{{cookiecutter.repo_name}}/docs/index.rst
+++ b/{{cookiecutter.repo_name}}/docs/index.rst
@@ -89,10 +89,10 @@ References
 Tools
 ^^^^^
 
--  `Cookiecutter <http://cookiecutter.readthedocs.org/en/latest/>`_
+-  `Cookiecutter <https://cookiecutter.readthedocs.io/en/latest/>`_
 -  `PyInvoke <http://www.pyinvoke.org/>`_
 -  `pytest <http://pytest.org/latest/contents.html>`_
--  `tox <https://tox.readthedocs.org/en/latest/>`_
+-  `tox <https://tox.readthedocs.io/en/latest/>`_
 -  `Pylint <http://docs.pylint.org/>`_
 -  `twine <https://github.com/pypa/twine#twine>`_
 -  `bpython <http://docs.bpython-interpreter.org/>`_


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.